### PR TITLE
fix path to project.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
         {
             "taskName": "build",
             "args": [
-                "${workspaceRoot}\\project.json"
+                "${workspaceRoot}//project.json"
             ],
             "isBuildCommand": true,
             "problemMatcher": "$msCompile"


### PR DESCRIPTION
fix "Could not find project file" error on os x
